### PR TITLE
feature: added toggle option to ingnore stash affinities

### DIFF
--- a/SimpleStashie.cs
+++ b/SimpleStashie.cs
@@ -58,6 +58,10 @@ namespace SimpleStashie
             try
             {
                 Input.KeyDown(Keys.LControlKey);
+                if (Settings.IgnoreAffinities)
+                {
+                    Input.KeyDown(Keys.LShiftKey);
+                }
                 foreach (var item in items)
                 {
                     if (SlotIsIgnored(item.InventPosX, item.InventPosY)) continue;
@@ -78,6 +82,10 @@ namespace SimpleStashie
             finally
             {
                 Input.KeyUp(Keys.LControlKey);
+                if (Settings.IgnoreAffinities)
+                {
+                    Input.KeyUp(Keys.LShiftKey);
+                }
                 IsRunning = false;
             }
         }

--- a/SimpleStashieSettings.cs
+++ b/SimpleStashieSettings.cs
@@ -9,6 +9,9 @@ namespace SimpleStashie
     {
         public ToggleNode Enable { get; set; } = new ToggleNode(true);
 
+        [Menu("Ignore Stash Affinities")]
+        public ToggleNode IgnoreAffinities { get; set; } = new ToggleNode(false);
+
         [Menu("Stash Inventory Hotkey")]
         public HotkeyNode StashItKey { get; set; } = new HotkeyNode(Keys.F2);
 


### PR DESCRIPTION
Found useful while aurabotting with various parties; used to keep looted items separated for easy splitting later.  